### PR TITLE
Fixed memory size problems 

### DIFF
--- a/ytmusic-header-capture/src/components/audio/Controls.tsx
+++ b/ytmusic-header-capture/src/components/audio/Controls.tsx
@@ -138,25 +138,6 @@ export const Controls = () => {
 		return () => chrome.runtime.onMessage.removeListener(listener)
 	}, [isPlaying])
 
-	/* Handle animation for the progress bar once the audio playback begins */
-	// const updateProgress = useCallback(() => {
-	// 	const listener = (message: any, sender: any, sendResponse: any) => {
-	// 		if (message.type === "AUDIO_PROGRESS" && isPlaying){
-	// 			const currentTime = message.payload.currentTime
-	// 			dispatch(setTimeProgress(currentTime))
-	// 			if (progressBarRef?.current){
-	// 				progressBarRef.current.value = currentTime.toString()
-	// 				progressBarRef.current.style.setProperty(
-	// 					"--range-progress",
-	// 					`${(currentTime/duration) * 100}%`
-	// 				)
-	// 			}
-	// 		}
-	// 	}
-	// 	chrome.runtime.onMessage.addListener(listener)
-	// 	return () => chrome.runtime.onMessage.removeListener(listener)
-	// }, [isPlaying, duration, timeProgress, progressBarRef])
-
 	const startAnimation = useCallback(() => {
 		if (progressBarRef.current && duration){
 			const animate = () => {


### PR DESCRIPTION
- moved the listener for audio progress outside of the `updateProgress` function. That way, it won't create a listener on every animation frame.
- Now, the listener will take the `timeProgress` update the current time in the redux state., and the actual  `updateProgressUI` in the animation will take the updated time from the redux store and repaint the progress bar.
